### PR TITLE
move cvat's KF in & use BRUTEFORCE mather to speed up

### DIFF
--- a/GenshinImpact_AutoMap/ATM_TM_SurfMap.h
+++ b/GenshinImpact_AutoMap/ATM_TM_SurfMap.h
@@ -32,14 +32,21 @@ class ATM_TM_SurfMap
 
 	Point2d pos;
 
-	 int stateNum = 4;
-	 int measureNum = 2;
+	int stateNum = 2;
+	int measureNum = 2;
+	int controlNum = 2;
 
 	KalmanFilter KF;
 	Mat state; /* (phi, delta_phi) */
 	Mat processNoise;
 	Mat measurement;
 
+	// ab's inertia filter
+	cv::Mat last_mini_map;
+	bool inited = false;
+	bool orb_match(cv::Mat &img1, cv::Mat &img2, cv::Point2f &offset);
+	void set_mini_map(const cv::Mat &giMiniMapRef);
+	bool control_odometer_calculation(const cv::Mat &giMiniMapRef, cv::Point2d &control, double scale);
 public:
 	ATM_TM_SurfMap();
 	~ATM_TM_SurfMap();


### PR DESCRIPTION
# 把cvat实现的惯导移进来 

srds，还没pr进去（

# 把匹配从FLANN改成了暴力

在cvat里面的提升是1000ms->70ms。

但是配automap环境是编译安装了opencv，而cvat用的裁剪的opencv。可能某些加速选项在cvat里被裁剪掉了。

目前是把单例去了，同时运行修改后的和之前的版本，传送过后响应普遍快了一点。如果有需要，还是测一下具体数据。

